### PR TITLE
USBConfiguration: Only count proper interfaces, not alternate settings.

### DIFF
--- a/facedancer/USBConfiguration.py
+++ b/facedancer/USBConfiguration.py
@@ -99,7 +99,7 @@ class USBConfiguration(USBDescribable):
 
         max_power_mA = self.max_power * 2
         return "<USBConfiguration index={} num_interfaces={} attributes=0x{:02X} max_power={}mA>".format(
-            self.configuration_index, len(self.interfaces), self.attributes, max_power_mA)
+            self.configuration_index, len(set(interface.number for interface in self.interfaces)), self.attributes, max_power_mA)
 
 
     def set_device(self, device):
@@ -120,7 +120,7 @@ class USBConfiguration(USBDescribable):
                 2,          # descriptor type 2 == configuration
                 total_len & 0xff,
                 (total_len >> 8) & 0xff,
-                len(self.interfaces),
+                len(set(interface.number for interface in self.interfaces)),
                 self.configuration_index,
                 self.configuration_string_index,
                 self.attributes,


### PR DESCRIPTION
If an emulated device has alternate settings, don't count them as unique interfaces to avoid the wrong number appearing in the returned descriptor.

Problematic example:
```
class USBDemoDevice(USBDevice):
    name = "USB demo device"

    def __init__(self, maxusb_app, verbose=0):
        interfaces = [
            USBDemoInterface(verbose=verbose, number=0, alternate=0),
            USBDemoInterface(verbose=verbose, number=0, alternate=1),
            USBDemoInterface(verbose=verbose, number=0, alternate=2),
            USBDemoInterface(verbose=verbose, number=0, alternate=3)
        ]

        config = USBConfiguration(
                1,                  # index
                "Demo config",      # string desc
                interfaces          # interfaces
        )
```
Outcome:
`[ 2673.631360] usb 1-3: config 1 has 1 interface, different from the descriptor's value: 4`