### PR TITLE
fix HID modifiers

### DIFF
--- a/USBKeyboard.py
+++ b/USBKeyboard.py
@@ -61,7 +61,7 @@ class USBKeyboardInterface(USBInterface):
         self.type_letter(letter)
 
     def type_letter(self, letter, modifiers=0):
-        data = bytes([ 0, 0, ord(letter) ])
+        data = bytes([ modifiers, 0, ord(letter) ])
 
         if self.verbose > 2:
             print(self.name, "sending keypress 0x%02x" % ord(letter))


### PR DESCRIPTION
modifiers (e.g. holding shift while sending key) should be the first byte in the HID response