### PR TITLE
Support descriptors with non-standard length.

### DIFF
--- a/facedancer/USBConfiguration.py
+++ b/facedancer/USBConfiguration.py
@@ -52,7 +52,7 @@ class USBConfiguration(USBDescribable):
 
         # Unpack the main colleciton of data into the descriptor itself.
         descriptor_type, total_length, num_interfaces, index, string_index, \
-            attributes, max_power = struct.unpack('<xBHBBBBB', data[0:length])
+            attributes, max_power = struct.unpack_from('<xBHBBBBB', data[0:length])
 
         # Extract the subordinate descriptors, and parse them.
         interfaces = cls._parse_subordinate_descriptors(data[length:total_length])

--- a/facedancer/USBDevice.py
+++ b/facedancer/USBDevice.py
@@ -103,7 +103,7 @@ class USBDevice(USBDescribable):
         spec_version_msb, spec_version_lsb, device_class, device_subclass, device_protocol, \
                 max_packet_size_ep0, vendor_id, product_id, device_rev_msb, device_rev_lsb, \
                 manufacturer_string_index, product_string_index, \
-                serial_number_string_index, num_configurations = struct.unpack("<xxBBBBBBHHBBBBBB", data)
+                serial_number_string_index, num_configurations = struct.unpack_from("<xxBBBBBBHHBBBBBB", data)
 
         # FIXME: generate better placeholder configurations
         configurations  = [USBConfiguration()] * num_configurations

--- a/facedancer/USBEndpoint.py
+++ b/facedancer/USBEndpoint.py
@@ -52,7 +52,7 @@ class USBEndpoint(USBDescribable):
         """
 
         # Parse the core descriptor into its components...
-        address, attributes, max_packet_size, interval = struct.unpack("xxBBHB", data)
+        address, attributes, max_packet_size, interval = struct.unpack_from("xxBBHB", data)
 
         # ... and break down the packed fields.
         number        = address & 0x7F

--- a/facedancer/USBInterface.py
+++ b/facedancer/USBInterface.py
@@ -79,7 +79,7 @@ class USBInterface(USBDescribable):
         """
         interface_number, alternate_setting, num_endpoints, interface_class, \
                 interface_subclass, interface_protocol, interface_string_index \
-                = struct.unpack("xxBBBBBBB", data)
+                = struct.unpack_from("xxBBBBBBB", data)
         return cls(interface_number, alternate_setting, interface_class,
                    interface_subclass, interface_protocol, interface_string_index)
 


### PR DESCRIPTION
Using "struct.unpack_from" instead of "struct.unpack" so that it works for descriptors longer than spec defined sizes.