### PR TITLE
Have the device interface handle class requests to endpoint

### DIFF
--- a/facedancer/USBDevice.py
+++ b/facedancer/USBDevice.py
@@ -233,7 +233,7 @@ class USBDevice(USBDescribable):
         if req_type == USB.request_type_standard:
             handler_entity = recipient
         elif req_type == USB.request_type_class:
-            handler_entity = recipient.device_class
+            handler_entity = recipient.interface
         elif req_type == USB.request_type_vendor:
             handler_entity = recipient.device_vendor
 


### PR DESCRIPTION
Previously, a class request with endpoint as the recipient and with `wIndex != 1` would fail, as USBEndpoint doesn't have a `device_class` attribute.