### PR TITLE
Support max packet size < 64 of endpoint 0 correctly

### DIFF
--- a/facedancer/USBDevice.py
+++ b/facedancer/USBDevice.py
@@ -151,7 +151,7 @@ class USBDevice(USBDescribable):
         }
 
     def connect(self):
-        self.maxusb_app.connect(self)
+        self.maxusb_app.connect(self, self.max_packet_size_ep0)
 
         # skipping USB.state_attached may not be strictly correct (9.1.1.{1,2})
         self.state = USB.state_powered

--- a/facedancer/future/device.py
+++ b/facedancer/future/device.py
@@ -123,7 +123,7 @@ class USBBaseDevice(USBDescribable, USBRequestHandler):
         if self.backend is None:
             self.backend = FacedancerUSBApp()
 
-        self.backend.connect(self)
+        self.backend.connect(self, self.max_packet_size_ep0)
 
 
     def disconnect(self):


### PR DESCRIPTION
If USBDevice.max_packet_size_ep0 was set to a value
smaller than 64 the pakets send to the host were
still 64 bytes in size.