### PR TITLE
Fix typos

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -91,6 +91,9 @@ ENV/
 .ropeproject
 tags
 
+# IntelliJ Project
+.idea/
+
 # Release files
 VERSION
 release-files

--- a/examples/template.py
+++ b/examples/template.py
@@ -16,7 +16,7 @@ class TemplateDevice(USBDevice):
     """ This class is meant to act as a template to help you get acquainted with FaceDancer."""
 
     #
-    # Core 'dataclass' defintions.
+    # Core 'dataclass' definitions.
     # These define the basic way that a FaceDancer device advertises itself to the host.
     #
     # Every one of these is optional. The defaults are relatively sane, so you can mostly
@@ -52,8 +52,8 @@ class TemplateDevice(USBDevice):
     # This tuple is a list of languages we're choosing to support.
     # This gives us an opportunity to provide strings in various languages.
     # We don't typically use this; so we can leave this set to a language of
-    # your choice. 
-    supported_langauges      : tuple = (LanguageIDs.ENGLISH_US,)
+    # your choice.
+    supported_languages      : tuple = (LanguageIDs.ENGLISH_US,)
 
     # The revision of the device hardware. This doesn't matter to the USB specification,
     # but it's sometimes read by drivers.
@@ -67,7 +67,7 @@ class TemplateDevice(USBDevice):
     #
     # We'll define a single configuration on our device. To be compliant,
     # every device needs at least a configuration and an interface.
-    # 
+    #
     # Note that we don't need to do anything special to have this be used.
     # As long as we're using the @use_inner_classes_automatically decorator,
     # this configuration will automatically be instantiated and used.
@@ -151,7 +151,7 @@ class TemplateDevice(USBDevice):
                 # For a full speed device, a max-size value of 64 is typical.
                 max_packet_size      : int = 64
 
-                # For interupt endpoints, the interval specifies how often the host should
+                # For interrupt endpoints, the interval specifies how often the host should
                 # poll the endpoint, in milliseconds. 10ms is a typical value.
                 interval             : int = 0
 
@@ -239,7 +239,7 @@ class TemplateDevice(USBDevice):
     @vendor_request_handler(number=1, direction=USBDirection.OUT)
     @to_device
     def handle_another_request(self, request):
-        
+
         #
         # Another set of convenience decorators exist to refine requests.
         # Decorators like `to_device` or `to_any_endpoint` chain with our
@@ -277,5 +277,5 @@ main(TemplateDevice)
 
 #
 # Of course, this template looks verbose as heck.
-# For an example that's much less verbnose, check out `examples/hackrf-info.py`.
+# For an example that's much less verbose, check out `examples/hackrf-info.py`.
 #

--- a/facedancer/USBConfiguration.py
+++ b/facedancer/USBConfiguration.py
@@ -43,14 +43,14 @@ class USBConfiguration(USBDescribable):
     def from_binary_descriptor(cls, data):
         """
         Generates a new USBConfiguration object from a configuration descriptor,
-        handling any attached subordiate descriptors.
+        handling any attached subordinate descriptors.
 
         data: The raw bytes for the descriptor to be parsed.
         """
 
         length = data[0]
 
-        # Unpack the main colleciton of data into the descriptor itself.
+        # Unpack the main collection of data into the descriptor itself.
         descriptor_type, total_length, num_interfaces, index, string_index, \
             attributes, max_power = struct.unpack_from('<xBHBBBBB', data[0:length])
 
@@ -62,7 +62,7 @@ class USBConfiguration(USBDescribable):
     @classmethod
     def _parse_subordinate_descriptors(cls, data):
         """
-        Generates descriptor objects from the list of subordinate desciptors.
+        Generates descriptor objects from the list of subordinate descriptors.
 
         data: The raw bytes for the descriptor to be parsed.
         """
@@ -93,7 +93,7 @@ class USBConfiguration(USBDescribable):
 
     def __repr__(self):
         """
-        Generates a pretty form of the configuation for printing.
+        Generates a pretty form of the configuration for printing.
         """
         # TODO: make attributes readable
 

--- a/facedancer/USBDevice.py
+++ b/facedancer/USBDevice.py
@@ -244,7 +244,7 @@ class USBDevice(USBDescribable):
         handler = handler_entity.request_handlers.get(req.request, None)
 
         if not handler:
-            print(self.name, "received unhandled EP0 control request; stallling:\n {}".format(repr(req)))
+            print(self.name, "received unhandled EP0 control request; stalling:\n {}".format(repr(req)))
             self.maxusb_app.stall_ep0()
             return
 
@@ -401,7 +401,7 @@ class USBDevice(USBDescribable):
         # HACK: blindly acknowledge request
         self.ack_status_stage()
 
-        # notify the device of the recofiguration, in case
+        # notify the device of the reconfiguration, in case
         # it needs to e.g. set up endpoints accordingly
         self.maxusb_app.configured(self.configuration)
 
@@ -462,7 +462,7 @@ class USBDeviceRequest:
         5: 'SET_ADDRESS',
         6: 'GET_DESCRIPTOR',
         7: 'SET_DESCRIPTOR',
-        8: 'GET_CONFIGRUATION',
+        8: 'GET_CONFIGURATION',
         9: 'SET_CONFIGURATION',
         10: 'GET_INTERFACE',
         11: 'SET_INTERFACE',

--- a/facedancer/USBInterface.py
+++ b/facedancer/USBInterface.py
@@ -59,7 +59,7 @@ class USBInterface(USBDescribable):
 
     def _handle_legacy_interface_class(self, interface_class, descriptors):
         """
-        Constructs a USBClass object from a legacy informtion set.
+        Constructs a USBClass object from a legacy information set.
         """
 
         iclass_desc_num = USB.interface_class_to_descriptor_type(interface_class)

--- a/facedancer/USBProxy.py
+++ b/facedancer/USBProxy.py
@@ -44,7 +44,7 @@ class USBProxyFilter:
         """
         Filters the data response from the proxied device during an IN control
         request. This allows us to modify the data returned from the proxied
-        devide during a setup stage.
+        device during a setup stage.
 
         req: The request that was issued to the target host.
         data: The data being proxied during the data stage.
@@ -90,7 +90,7 @@ class USBProxyFilter:
     def filter_in_token(self, ep_num):
         """
         Filters an IN token before it's passed to the proxied device.
-        This allows modification of e.g. the endpoint or absorpotion of
+        This allows modification of e.g. the endpoint or absorption of
         the IN token before it's issued to the real device.
 
         ep_num: The endpoint number on which the IN token is to be proxied.
@@ -106,7 +106,7 @@ class USBProxyFilter:
         to the host issuing an IN token).
 
         ep_num: The endpoint number associated with the data packet.
-        data: The data packet recieved from the proxied device.
+        data: The data packet received from the proxied device.
 
         returns: A modified version of the arguments. If data is set to none,
             the packet will be absorbed, and a NAK will be issued instead of
@@ -120,7 +120,7 @@ class USBProxyFilter:
         Filters a packet sent from the host via an OUT token.
 
         ep_num: The endpoint number associated with the data packet.
-        data: The data packet recieved from host.
+        data: The data packet received from host.
 
         returns: A modified version of the arguments. If data is set to none,
             the packet will be absorbed,

--- a/facedancer/backends/MAXUSBApp.py
+++ b/facedancer/backends/MAXUSBApp.py
@@ -212,7 +212,7 @@ class MAXUSBApp(FacedancerApp):
         Sets the device address of the Facedancer. Usually only used during
         initial configuration.
 
-        address: The address that the Facedance should assume.
+        address: The address that the Facedancer should assume.
         """
 
         # The MAXUSB chip handles this for us, so we don't need to do anything.
@@ -222,12 +222,12 @@ class MAXUSBApp(FacedancerApp):
     def configured(self, configuration):
         """
         Callback that's issued when a USBDevice is configured, e.g. by the
-        SET_CONFIGRUATION request. Allows us to apply the new configuration.
+        SET_CONFIGURATION request. Allows us to apply the new configuration.
 
-        configuration: The configruation applied by the SET_CONFIG request.
+        configuration: The configuration applied by the SET_CONFIG request.
         """
 
         # For the MAXUSB case, we don't need to do anything, though it might
-        # be nice to print a message or store the active coniguration for
+        # be nice to print a message or store the active configuration for
         # use by the USBDevice, etc. etc.
         pass

--- a/facedancer/backends/greatdancer.py
+++ b/facedancer/backends/greatdancer.py
@@ -122,7 +122,7 @@ class GreatDancerApp(FacedancerApp):
 
     def init_commands(self):
         """
-        API compatibility fucntion; not necessary for GreatDancer.
+        API compatibility function; not necessary for GreatDancer.
         """
         pass
 
@@ -139,10 +139,10 @@ class GreatDancerApp(FacedancerApp):
     def ack_status_stage(self, direction=HOST_TO_DEVICE, endpoint_number=0, blocking=False):
         """
             Handles the status stage of a correctly completed control request,
-            by priming the appropriate endpint to handle the status phase.
+            by priming the appropriate endpoint to handle the status phase.
 
             direction: Determines if we're ACK'ing an IN or OUT vendor request.
-                (This should match the direcion of the DATA stage.)
+                (This should match the direction of the DATA stage.)
             endpoint_number: The endpoint number on which the control request
                 occurred.
             blocking: True if we should wait for the ACK to be fully issued
@@ -274,7 +274,7 @@ class GreatDancerApp(FacedancerApp):
     @staticmethod
     def _endpoint_address(ep_num, direction):
         """
-        Returns the endpoint number that corresponds to a given directio
+        Returns the endpoint number that corresponds to a given direction
         and address.
         """
         if direction:
@@ -310,7 +310,7 @@ class GreatDancerApp(FacedancerApp):
         initial configuration.
 
         address: The address that the GreatDancer should assume.
-        defer: True iff the set_addres request should wait for an active transaction to finish.
+        defer: True iff the set_address request should wait for an active transaction to finish.
         """
 
         self.api.set_address(address, 1 if defer else 0)
@@ -477,7 +477,7 @@ class GreatDancerApp(FacedancerApp):
 
         # Finally, after completing all of the above, we may now have idle
         # (unprimed) endpoints. For OUT endpoints, we'll need to re-prime them
-        # so we're ready for reciept; for IN endpoints, we'll want to give the
+        # so we're ready for receipt; for IN endpoints, we'll want to give the
         # emulated device a chance to provide new data.
         self._handle_transfer_readiness()
 
@@ -503,7 +503,7 @@ class GreatDancerApp(FacedancerApp):
         There's no harm in calling this if a transaction isn't complete, but it _must_
         be called at least once for each completed transaction.
 
-        endpoint_number: The endpoint number whose transfer desctiprots should be cleaned
+        endpoint_number: The endpoint number whose transfer descriptors should be cleaned
             up.
         direction: The endpoint direction for which TD's should be cleaned.
         """
@@ -523,7 +523,7 @@ class GreatDancerApp(FacedancerApp):
 
     def _handle_transfer_complete_on_endpoint(self, endpoint_number, direction):
         """
-        Handles a known-compelted transfer on a given endpoint.
+        Handles a known-completed transfer on a given endpoint.
 
         endpoint_number: The endpoint number for which a setup event should be serviced.
         """
@@ -532,11 +532,11 @@ class GreatDancerApp(FacedancerApp):
         # that we need to handle.
         if direction == self.HOST_TO_DEVICE:
 
-            # Special case: if we've just recieved data on a control endpoint,
+            # Special case: if we've just received data on a control endpoint,
             # we're completing a control request.
             if self._is_control_endpoint(endpoint_number):
 
-                # If we recieved a setup packet to handle, handle it.
+                # If we received a setup packet to handle, handle it.
                 if self.pending_control_request:
 
                     # Read the rest of the data from the endpoint, completing
@@ -588,7 +588,7 @@ class GreatDancerApp(FacedancerApp):
 
     def _prime_out_endpoint(self, endpoint_number):
         """
-        Primes an out endpoint, allowing it to recieve data the next time the host chooses to send it.
+        Primes an out endpoint, allowing it to receive data the next time the host chooses to send it.
 
         endpoint_number: The endpoint that should be primed.
         """
@@ -719,7 +719,7 @@ class GreatDancerApp(FacedancerApp):
         """
         Configures the GreatDancer's endpoints to match the provided configuration.
 
-        configurate: The USBConfigruation object that describes the endpoints provided.
+        configurate: The USBConfiguration object that describes the endpoints provided.
         """
         endpoint_triplets = self._generate_endpoint_config_arguments(configuration)
 
@@ -733,9 +733,9 @@ class GreatDancerApp(FacedancerApp):
     def configured(self, configuration):
         """
         Callback that's issued when a USBDevice is configured, e.g. by the
-        SET_CONFIGRUATION request. Allows us to apply the new configuration.
+        SET_CONFIGURATION request. Allows us to apply the new configuration.
 
-        configuration: The configruation applied by the SET_CONFIG request.
+        configuration: The configuration applied by the SET_CONFIG request.
         """
         self._configure_endpoints(configuration)
         self.configuration = configuration

--- a/facedancer/backends/greathost.py
+++ b/facedancer/backends/greathost.py
@@ -12,7 +12,7 @@ from ..core import *
 
 class GreatDancerHostApp(FacedancerUSBHost):
     """
-    Class that represets a GreatFET-based USB host.
+    Class that represents a GreatFET-based USB host.
     """
     app_name = "GreatDancer Host"
 
@@ -409,7 +409,7 @@ class GreatDancerHostApp(FacedancerUSBHost):
         if self.verbose > 4:
             print("Supposedly, we've got {} bytes of data to read".format(length))
 
-        # If there's no data available, we don't need to waste time reading anyting.
+        # If there's no data available, we don't need to waste time reading anything.
         if length == 0:
             return b''
 

--- a/facedancer/backends/libusbhost.py
+++ b/facedancer/backends/libusbhost.py
@@ -13,7 +13,7 @@ from ..core import *
 
 class LibUSBHostApp(FacedancerUSBHost):
     """
-    Class that represets a libusb-based USB host.
+    Class that represents a libusb-based USB host.
     """
     app_name = "LibUSB Host"
 
@@ -35,7 +35,7 @@ class LibUSBHostApp(FacedancerUSBHost):
         if os.environ.get('LIBUSB_ADDRESS'):
             return True
 
-        # Never automaticaly instantiate the libusb backend,
+        # Never automatically instantiate the libusb backend,
         # as it's not a full implementation and requires host-OS oddities.
         return False
 
@@ -46,7 +46,7 @@ class LibUSBHostApp(FacedancerUSBHost):
         """
 
         self.verbose = verbose
-    
+
         # If we have a specified bus/port, accept them.
         # TODO: accept these via quirks?
         desired_bus = os.environ.get('LIBUSB_BUS')
@@ -191,7 +191,7 @@ class LibUSBHostApp(FacedancerUSBHost):
 
         endpoint_number -- The endpoint number on which to send.
         expected_read_size -- The expected amount of data to be read.
-        data_packet_pid -- The data packet PID to use (1 or 0). 
+        data_packet_pid -- The data packet PID to use (1 or 0).
             Ignored if the endpoint is set to automatically alternate data PIDs.
 
         raises an IOError on a communications error or stall
@@ -206,7 +206,7 @@ class LibUSBHostApp(FacedancerUSBHost):
         request_type -- Determines if this is a standard, class, or vendor request. Accepts a REQUEST_TYPE_* constant.
         recipient -- Determines the context in which this command is interpreted. Accepts a REQUEST_RECIPIENT_* constant.
         request -- The request number to be performed.
-        value, index -- The standad USB request arguments, to be included in the setup packet. Their meaning varies
+        value, index -- The standard USB request arguments, to be included in the setup packet. Their meaning varies
             depending on the request.
         length -- The maximum length of data expected in response, or 0 if we don't expect any data back.
         """
@@ -223,7 +223,7 @@ class LibUSBHostApp(FacedancerUSBHost):
         request_type -- Determines if this is a standard, class, or vendor request. Accepts a REQUEST_TYPE_* constant.
         recipient -- Determines the context in which this command is interpreted. Accepts a REQUEST_RECIPIENT_* constant.
         request -- The request number to be performed.
-        value, index -- The standad USB request arguments, to be included in the setup packet. Their meaning varies
+        value, index -- The standard USB request arguments, to be included in the setup packet. Their meaning varies
             depending on the request.
         data -- The data to be transmitted with this control request.
         """

--- a/facedancer/backends/raspdancer.py
+++ b/facedancer/backends/raspdancer.py
@@ -1,7 +1,7 @@
 #
 # Raspdancer
 #
-# Implementation of the Facedacner API that supports direct access to the MAX324x
+# Implementation of the Facedancer API that supports direct access to the MAX324x
 # chip via a RasPi's SoC SPI bus. Emulates talking to a Facedancer, but ignores
 # the details of the GreatFET protocol.
 #
@@ -38,7 +38,7 @@ class RaspdancerMaxUSBApp(MAXUSBApp):
             rd = Raspdancer()
             return True
         except ImportError as e:
-            logging.info("Skipping Raspdancer devices, as prequisites aren't installed ({}).".format(e))
+            logging.info("Skipping Raspdancer devices, as perquisites aren't installed ({}).".format(e))
             return False
         except:
             return False

--- a/facedancer/core.py
+++ b/facedancer/core.py
@@ -30,8 +30,8 @@ class FacedancerApp:
     @classmethod
     def autodetect(cls, verbose=0, quirks=None):
         """
-        Convenience function that automatically creates the apporpriate
-        sublass based on the BOARD environment variable and some crude internal
+        Convenience function that automatically creates the appropriate
+        subclass based on the BOARD environment variable and some crude internal
         automagic.
 
         verbose: Sets the verbosity level of the relevant app. Increasing
@@ -84,7 +84,7 @@ class FacedancerApp:
         class to connect to a facedancer given the board_name and other
         environmental factors.
 
-        board: The name of the backend, as typically retreived from the BACKEND
+        board: The name of the backend, as typically retrieved from the BACKEND
             environment variable, or None to try figuring things out based
             on other environmental factors.
         """
@@ -160,8 +160,8 @@ class FacedancerUSBHost:
     @classmethod
     def autodetect(cls, verbose=0, quirks=None):
         """
-        Convenience function that automatically creates the apporpriate
-        sublass based on the BOARD environment variable and some crude internal
+        Convenience function that automatically creates the appropriate
+        subclass based on the BOARD environment variable and some crude internal
         automagic.
 
         verbose: Sets the verbosity level of the relevant app. Increasing
@@ -218,7 +218,7 @@ class FacedancerUSBHost:
         class to connect to a facedancer given the board_name and other
         environmental factors.
 
-        board: The name of the backend, as typically retreived from the BACKEND
+        board: The name of the backend, as typically retrieved from the BACKEND
             environment variable, or None to try figuring things out based
             on other environmental factors.
         """
@@ -231,7 +231,7 @@ class FacedancerUSBHost:
 
         is_in -- True iff this is a DEVICE-to-HOST request.
         req_type -- The type of request to be used.
-        recipient -- The context in which this request should be interprted.
+        recipient -- The context in which this request should be interpreted.
 
         returns -- a request_type byte
         """
@@ -276,7 +276,7 @@ class FacedancerUSBHost:
         request_type -- Determines if this is a standard, class, or vendor request. Accepts a REQUEST_TYPE_* constant.
         recipient -- Determines the context in which this command is interpreted. Accepts a REQUEST_RECIPIENT_* constant.
         request -- The request number to be performed.
-        value, index -- The standad USB request arguments, to be included in the setup packet. Their meaning varies
+        value, index -- The standard USB request arguments, to be included in the setup packet. Their meaning varies
             depending on the request.
         length -- The maximum length of data expected in response, or 0 if we don't expect any data back.
         """
@@ -318,7 +318,7 @@ class FacedancerUSBHost:
         request_type -- Determines if this is a standard, class, or vendor request. Accepts a REQUEST_TYPE_* constant.
         recipient -- Determines the context in which this command is interpreted. Accepts a REQUEST_RECIPIENT_* constant.
         request -- The request number to be performed.
-        value, index -- The standad USB request arguments, to be included in the setup packet. Their meaning varies
+        value, index -- The standard USB request arguments, to be included in the setup packet. Their meaning varies
             depending on the request.
         data -- The data to be transmitted with this control request.
         """
@@ -338,7 +338,7 @@ class FacedancerUSBHost:
 
     def initialize_device(self, apply_configuration=0, assign_address=0):
         """
-        Sets up a conenction to a directly-attached USB device.
+        Sets up a connection to a directly-attached USB device.
 
         apply_configuration -- If non-zero, the configuration with the given
             index will be applied to the relevant device.
@@ -403,7 +403,7 @@ class FacedancerUSBHost:
 
 
     def get_configuration_descriptor(self, index=0, include_subordinates=True):
-        """ Returns the device's configuration desctriptor.
+        """ Returns the device's configuration descriptor.
 
         include_subordinate -- if true, subordinate descriptors will also be returned
         """

--- a/facedancer/filters/logging.py
+++ b/facedancer/filters/logging.py
@@ -100,7 +100,7 @@ class USBProxyPrettyPrintFilter(USBProxyFilter):
         return datetime.datetime.now().strftime("[%H:%M:%S]")
 
     def _magic_decode(self, data):
-        """ Simple decode function that attempts to find a nice string represetation for the console."""
+        """ Simple decode function that attempts to find a nice string representation for the console."""
         try:
             return bytes(data).decode('utf-16le')
         except:

--- a/facedancer/filters/standard.py
+++ b/facedancer/filters/standard.py
@@ -94,7 +94,7 @@ class USBProxySetupFilters(USBProxyFilter):
 
                 self.device.configured(configuration)
 
-            # Otherwise, the host has applied a configruation without ever reading
+            # Otherwise, the host has applied a configuration without ever reading
             # its descriptor. This is mighty strange behavior!
             elif self.verbose > 0:
                 print("-- WARNING: Applying configuration {}, but we've never read that configuration's descriptor! --".format(configuration_index))

--- a/facedancer/future/configuration.py
+++ b/facedancer/future/configuration.py
@@ -170,12 +170,12 @@ class USBConfiguration(USBDescribable, AutoInstantiable, USBRequestHandler):
 
 
     def get_descriptor(self) -> bytes:
-        """ Returns this configurations's configuration descriptor, including subordinates. """
+        """ Returns this configuration's configuration descriptor, including subordinates. """
         interface_descriptors = bytearray()
 
         # FIXME: use construct
 
-        # All all subordinate descriptors together to create a big subordinate desciptor.
+        # All all subordinate descriptors together to create a big subordinate descriptor.
         interfaces = sorted(self.interfaces.values(), key=lambda item: item.number)
         for interface in interfaces:
             interface_descriptors += interface.get_descriptor()

--- a/facedancer/future/device.py
+++ b/facedancer/future/device.py
@@ -35,7 +35,7 @@ class USBBaseDevice(USBDescribable, USBRequestHandler):
 
     Fields:
         device_class/device_subclass/protocol_revision_number --
-                The USB descriptor fields that select the class, subclass, and protcol.
+                The USB descriptor fields that select the class, subclass, and protocol.
         vendor_id, product_id --
                 The USB vendor and product ID for this device.
         manufacturer_string, product_string, serial_number_string --
@@ -68,7 +68,7 @@ class USBBaseDevice(USBDescribable, USBRequestHandler):
 
     # I feel bad for putting this as the default language ID / propagating anglocentrism,
     # but this appears to be the only language ID supported by some systems, so here it is.
-    supported_langauges      : tuple = (LanguageIDs.ENGLISH_US,)
+    supported_languages      : tuple = (LanguageIDs.ENGLISH_US,)
 
     device_revision          : int  = 0
     usb_spec_version         : int  = 0x0002
@@ -387,7 +387,7 @@ class USBBaseDevice(USBDescribable, USBRequestHandler):
         doesn't exist. Note that even if `handle_data_received` is overridden,
         this method can still be called e.g. by configuration.handle_data_received.
 
-        Parameteres:
+        Parameters:
             endpoint_number -- The endpoint number on which the data was received.
             data            -- The raw bytes received on the relevant endpoint.
         """
@@ -582,7 +582,7 @@ class USBBaseDevice(USBDescribable, USBRequestHandler):
         print_html("")
         print_html("<b><u>Automatic Suggestions</u></b>")
         print_html("These suggestions are based on simple observed behavior;")
-        print_html("not all of these suggestions may be useful / desireable.")
+        print_html("not all of these suggestions may be useful / desirable.")
         print_html("")
 
         self._print_suggested_requests()
@@ -600,7 +600,7 @@ class USBBaseDevice(USBDescribable, USBRequestHandler):
             address -- The address to apply.
             defer   -- If true, the address change should be deferred
                        until the next time a control request ends. Should
-                       be set if we're changing the addres before we ack
+                       be set if we're changing the address before we ack
                        the relevant transaction.
         """
         self.address = address
@@ -643,15 +643,15 @@ class USBBaseDevice(USBDescribable, USBRequestHandler):
         return self.configurations[index + 1].get_descriptor()
 
 
-    def handle_get_supported_langauges_descriptor(self) -> bytes:
-        """ Returns the special string-descriptor-zero that indicates which langauges are supported. """
+    def handle_get_supported_languages_descriptor(self) -> bytes:
+        """ Returns the special string-descriptor-zero that indicates which languages are supported. """
 
         # Our string descriptor is going to have two header bytes, plus two bytes
         # for each language.
-        total_length = (len(self.supported_langauges) * 2) + 2
+        total_length = (len(self.supported_languages) * 2) + 2
         packet = bytearray([total_length, DescriptorTypes.STRING])
 
-        for language in self.supported_langauges:
+        for language in self.supported_languages:
             packet.extend(language.to_bytes(2, byteorder='little'))
 
         return bytes(packet)
@@ -661,7 +661,7 @@ class USBBaseDevice(USBDescribable, USBRequestHandler):
         """ Returns the string descriptor associated with a given index. """
 
         if index == 0:
-            return self.handle_get_supported_langauges_descriptor()
+            return self.handle_get_supported_languages_descriptor()
         else:
             return self.strings[index]
 

--- a/facedancer/future/endpoint.py
+++ b/facedancer/future/endpoint.py
@@ -18,13 +18,13 @@ from .types      import USBUsageType, USBStandardRequests
 
 @dataclass
 class USBEndpoint(USBDescribable, AutoInstantiable, USBRequestHandler):
-    """ Class represenging a USBEndpoint object.
+    """ Class representing a USBEndpoint object.
 
     Field:
         number          -- The endpoint number (without the direction bit) for this endpoint.
         direction       -- A USBDirection constant indicating this endpoint's direction.
 
-        transfer_type   -- A USBTransferType contant indicating the type of communications used.
+        transfer_type   -- A USBTransferType constant indicating the type of communications used.
         max_packet_size -- The maximum packet size for this endpoint.
         interval        -- The polling interval, for an INTERRUPT endpoint.
     """

--- a/facedancer/future/interface.py
+++ b/facedancer/future/interface.py
@@ -28,7 +28,7 @@ class USBInterface(USBDescribable, AutoInstantiable, USBRequestHandler):
         class_number, subclass_number, protocol_number --
                 The USB class adhered to on this interface; usually a USBDeviceClass constant.
         interface_string --
-                A short, descriptive string used to identify the endpoint; or None if not providd.
+                A short, descriptive string used to identify the endpoint; or None if not provided.
     """
     DESCRIPTOR_TYPE_NUMBER = 0x4
 

--- a/facedancer/future/request.py
+++ b/facedancer/future/request.py
@@ -27,7 +27,7 @@ def _wrap_with_field_matcher(func, field_name, field_value, match_index=False):
     As an example, if this is called with `field_name`='index' and 'field_value'=3,
     this modifies `func` so it is only executed for requests with an index of 3.
 
-    Parmaters:
+    Parameters:
         func        -- The handler function to wrap.
         field_name  -- The name of the field to check.
         field_value -- The value the given field must have for the function to execute.
@@ -222,7 +222,7 @@ class USBControlRequest:
 
     @classmethod
     def from_raw_bytes(cls, raw_bytes: bytes, *, device = None):
-        """ Creates a request object from a sequency of raw bytes.
+        """ Creates a request object from a sequence of raw bytes.
 
         Parameters:
             raw_bytes -- The raw bytes to create the object from.

--- a/legacy-applets/USBMassStorage.py
+++ b/legacy-applets/USBMassStorage.py
@@ -156,7 +156,7 @@ class USBMassStorageInterface(USBInterface):
             if self.verbose > 0:
                 print("{} handling {} ({}) {}:[{}]".format(direction_arrow, name.upper(), direction_name, expected_length, bytes_as_hex(cbw.cb[1:])))
 
-            # Delegate to its handler funciton.
+            # Delegate to its handler function.
             return handler(cbw)
 
         # Otherwise, run the unknown command handler.
@@ -767,7 +767,7 @@ class FAT32DiskImage(DiskImage):
 
     def handle_fat_read(self, address):
         """
-        Handles an access to the device's file allocaiton table.
+        Handles an access to the device's file allocation table.
         """
 
         # TODO: Create general method for reading from the FAT based on

--- a/legacy-applets/USBQCEDL.py
+++ b/legacy-applets/USBQCEDL.py
@@ -2,7 +2,7 @@
 USB Class definitions for Qualcomm QDLoader 9008 Firehose
 (c) B. Kerler 2018
 At least set up hwid and hash.
-serial and sbversion is optional for testing.
+serial and sblversion is optional for testing.
 Supports extraction of firehose/EDL loaders, saves as [hwid].bin in local directory
 '''
 
@@ -67,12 +67,12 @@ class USBSaharaInterface(USBInterface):
     SAHARA_EXEC_CMD_SWITCH_TO_STREAM_DLOAD = 0x05
     SAHARA_EXEC_CMD_READ_DEBUG_DATA = 0x06
     SAHARA_EXEC_CMD_GET_SOFTWARE_VERSION_SBL = 0x07
-    
+
     SAHARA_MODE_IMAGE_TX_PENDING = 0x0
     SAHARA_MODE_IMAGE_TX_COMPLETE = 0x1
     SAHARA_MODE_MEMORY_DEBUG = 0x2
     SAHARA_MODE_COMMAND = 0x3
-    
+
     def __init__(self, hash,serial,hwid,sblversion,verbose=0):
         descriptors = { }
         self.hwid=hwid
@@ -88,7 +88,7 @@ class USBSaharaInterface(USBInterface):
         self.buffer=bytes(b'')
         self.loader=bytes(b'')
         self.receive_buffer = bytes(b'')
-        
+
         self.endpoints = [
         USBEndpoint(
                 1,          # endpoint number
@@ -131,7 +131,7 @@ class USBSaharaInterface(USBInterface):
         elif ep==1:
             return self.endpoints[0].send(data)
         assert("Send_on_endpoint: wrong endpoint given.")
-        
+
     def send_data(self, data):
         #print ("TX: ")
         #rec=binascii.hexlify(data)
@@ -242,7 +242,7 @@ class USBSaharaInterface(USBInterface):
                 elif req[2] == self.SAHARA_EXEC_CMD_READ_DEBUG_DATA: #6
                     packet = reply.pack(self.SAHARA_EXECUTE_RSP, 0x10, self.SAHARA_EXEC_CMD_READ_DEBUG_DATA, 0x40)
                 '''
-                
+
                 self.send_data(packet)
                 print("Done SAHARA_EXECUTE_REQ.")
             elif opcode == self.SAHARA_EXECUTE_DATA: #0xF
@@ -348,7 +348,7 @@ class USBSaharaDevice(USBDevice):
     name = "USB QC Sahara EDL Device"
 
     def __init__(self, maxusb_app, verbose=0):
-    
+
         #z ultra c 6833 msm8974_23_4_aid_4
         #hash = bytearray.fromhex("49109A8016C239CD8F76540FE4D5138C87B2297E49C6B30EC31852330BDDB177")
         #hwid = 0x04000100E1007B00

--- a/legacy-applets/facedancer-host-enumeration.py
+++ b/legacy-applets/facedancer-host-enumeration.py
@@ -9,7 +9,7 @@ u = FacedancerUSBHostApp(verbose=3)
 u.initialize_device(assign_address=1, apply_configuration=1)
 
 # At this point, we can perform whatever communications we need to to use the target device.
-# Usually, this is accomplsihed using the send_on_endpoint and read_from_endpoint functions
+# Usually, this is accomplished using the send_on_endpoint and read_from_endpoint functions
 # for non-control requests, and the control_request_in and control_request out functions
 # for control requests.
 


### PR DESCRIPTION
Most are in comments/strings. The only value named changed is `supported_langauges` to `supported_languages` in `USBDevice`