### PR TITLE
fix(hid): correct bSize encoding for HID short items

### DIFF
--- a/facedancer/classes/hid/descriptor.py
+++ b/facedancer/classes/hid/descriptor.py
@@ -18,11 +18,26 @@ from ...descriptor import USBDescriptor, USBDescriptorTypeNumber
 
 def _hid_item_generator(constant) -> Tuple[int]:
     """ Generates a HID descriptor global item entry. """
-
+    # See See HID1.1 [6.2.2.1 Items Types and Tags]
+    size_code_map = {
+        0: 0b00,  # No data
+        1: 0b01,  # 1 byte
+        2: 0b10,  # 2 bytes
+        4: 0b11,  # 4 bytes
+    }
     # Generate a function that creates a item with
     # the relevant type...
     def hid_item(*octets):
-        return (constant | len(octets), *octets)
+        size = len(octets)
+        if size not in size_code_map:
+            raise ValueError(
+                f"HID short item can only have 0, 1, 2 or 4 data bytes, got {size}"
+            )
+
+        size_code = size_code_map[size]
+        prefix = constant | size_code
+
+        return (prefix, *octets)
 
     # ... and return it.
     return hid_item


### PR DESCRIPTION
This PR fixes an issue in the HID short item generator where the size field (bSize) was derived directly from the number of data bytes. According to the HID specification, the size bits do not represent the literal number of bytes, but instead use a 2-bit code:

- 00 → 0 bytes
- 01 → 1 byte
- 10 → 2 bytes
- 11 → 4 bytes

The previous implementation incorrectly used len(octets) as the value for these bits, resulting in malformed descriptors (for example, a 4-byte item still produced bSize = 0).

Small example:

```
from facedancer.classes.hid.usage import *
from facedancer.classes.hid.descriptor import *
from facedancer.classes.hid.keyboard import *
from facedancer.classes.hid.descriptor import _hid_item_generator


REPORT_SIZE        = _hid_item_generator(0b0111_01_00)
reports = REPORT_SIZE(0xFF,0xFF,0xFF,0xFF)
print(f'reports (bin): {bin(reports[0])}') # Will "0b1110100", but must be "0b1110111"
```

<img width="817" height="484" alt="image" src="https://github.com/user-attachments/assets/acdc7ffd-6ffd-4534-a123-11a9ded357dc" />
