### PR TITLE
Update for changes in annotations with Python 3.14

### DIFF
--- a/docs/requirements.txt
+++ b/docs/requirements.txt
@@ -1,4 +1,3 @@
-setuptools
 sphinx==7.2.6
 sphinx_rtd_theme==2.0.0
 sphinxcontrib-apidoc

--- a/docs/source/conf.py
+++ b/docs/source/conf.py
@@ -1,7 +1,4 @@
-import os, pkg_resources, sys, time
-sys.path.insert(0, os.path.abspath("../../"))
-sys.path.insert(0, os.path.abspath('../../facedancer'))
-
+import time
 import sphinx_rtd_theme
 
 extensions = [
@@ -12,9 +9,9 @@ extensions = [
 
 project = 'Facedancer'
 copyright = time.strftime('2018-%Y, Great Scott Gadgets')
-author = 'Great Scott Gadget'
+author = 'Great Scott Gadgets'
 
-version = pkg_resources.get_distribution('facedancer').version
+version = ''
 release = ''
 
 

--- a/facedancer/magic.py
+++ b/facedancer/magic.py
@@ -4,22 +4,41 @@
 """ Functionally for automatic instantiations / tracking via decorators. """
 
 import inspect
+import sys
 
 from abc         import ABCMeta, abstractmethod
 from dataclasses import dataclass, is_dataclass, field, fields
 
-
 class DescribableMeta(ABCMeta):
     """ Metaclass for USBDescribable subclasses. """
-    def __new__(cls, name, bases, classdict):
-        annotations = classdict.setdefault('__annotations__', {})
-        for base in bases:
-            if is_dataclass(base):
-                for field in fields(base):
-                    if field.name in classdict:
-                        if field.name not in annotations:
-                            annotations[field.name] = str(field.type)
-        new_cls = ABCMeta.__new__(cls, name, bases, classdict)
+    def __new__(cls, name, bases, ns):
+        """ Construct a new dataclass from the given class which
+            inherits all type annotations from its base classes. """
+
+        # Get annotations for the current class namespace.
+        if "__annotations__" in ns:
+            annotations = ns["__annotations__"]
+        elif sys.version_info >= (3, 14):
+            # See: https://peps.python.org/pep-0749/#annotations-and-metaclasses
+            import annotationlib
+            if annotate := annotationlib.get_annotate_from_class_namespace(ns):
+                annotations = annotationlib.call_annotate_function(
+                    annotate,
+                    annotationlib.Format.FORWARDREF
+                )
+            else:
+                annotations = ns.setdefault('__annotations__', {})
+        else:
+            annotations = ns.setdefault('__annotations__', {})
+
+        # For every field, of every base class, if our current class
+        # namespace does not have an annotation for it, add one.
+        for base in filter(is_dataclass, bases):
+            for field in fields(base):
+                if field.name in ns and field.name not in annotations:
+                    annotations[field.name] = str(field.type)
+
+        new_cls = ABCMeta.__new__(cls, name, bases, ns)
         return dataclass(new_cls, kw_only=True)
 
 


### PR DESCRIPTION
Python 3.14 introduces deferred evaluation of annotations ([PEP 649](https://peps.python.org/pep-0649/) and [PEP 749](https://peps.python.org/pep-0749/)). 

Code that relies on manipulating the `__annotations__` attribute directly needs to, instead, make use of `annotationlib` and the `get_annotations()` function called with the `format=Format.FORWARDREF` argument.

In this PR we'll use the `typeextensions` library which provides a backward-compatible implementation for versions of Python `<3.14`.

More information: https://docs.python.org/3/whatsnew/3.14.html#whatsnew314-porting-annotations

--
Closes #172 